### PR TITLE
configure puppet master for autosigning.

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -93,6 +93,7 @@ puppet  IN      A       $ipaddr
 	agent                     => false,
 	puppet_master_package     => 'puppetmaster',
     puppet_server             => $hostname,
+    autosign                => true,
 	storeconfigs              => true,
 	storeconfigs_dbadapter    => 'puppetdb',
     storeconfigs_dbserver     => $hostname,


### PR DESCRIPTION
This commit ensures that the puppet master will sign any incoming
certificates.

Since the vagrant environments are just test environments, having
autosign default to true makes sense.
