### PR TITLE
Fixed problem with Rakefile downloading Ubuntu Image

### DIFF
--- a/env/full-ubuntu-image/Rakefile
+++ b/env/full-ubuntu-image/Rakefile
@@ -7,6 +7,6 @@ desc 'clone all required modules'
           puts "Image file already downloaed please delete if you wish to download again"
       else
           puts "Download ubuntu install image, this may take a long time"
-          sh %("curl http://releases.ubuntu.com/12.04/ubuntu-12.04-server-amd64.iso > images/ubuntu-12.04-server-amd64.iso")
+          sh "curl http://releases.ubuntu.com/12.04.2/ubuntu-12.04.2-server-amd64.iso > images/ubuntu-12.04-server-amd64.iso"
       end
   end


### PR DESCRIPTION
curl was unable to download the ubuntu iso.  It seems there was a syntax problem in the rake file.  I removed the syntax problem and curl was able to download the image successfully.  I also changed the default image to 12.04.2.

If interested, here is the error that this fork fixes:

```
rake setup
Running setup task
librarian-puppet install
Download ubuntu install image, this may take a long time
"curl http://releases.ubuntu.com/12.04.2/ubuntu-12.04.2-server-amd64.iso > images/ubuntu-12.04-server-amd64.iso"
sh: 1: curl http://releases.ubuntu.com/12.04.2/ubuntu-12.04.2-server-amd64.iso > images/ubuntu-12.04-server-amd64.iso: not found
rake aborted!
Command failed with status (127): ["curl http://releases.ubuntu.com/12.04.2/u...]
```
